### PR TITLE
update to tkeylibs v0.0.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,13 @@ CC = clang
 INCLUDE=$(LIBDIR)/include
 
 # If you want libcommon's qemu_puts() et cetera to output something on our QEMU
-# debug port, remove -DNODEBUG below
+# debug port, use -DQEMU_DEBUG below
 CFLAGS = -target riscv32-unknown-none-elf -march=rv32iczmmul -mabi=ilp32 -mcmodel=medany \
    -static -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf \
    -fno-builtin-putchar -nostdlib -mno-relax -flto -g \
    -Wall -Werror=implicit-function-declaration \
-   -I $(INCLUDE) -I $(LIBDIR)  \
-   -DNODEBUG
+   -I $(INCLUDE) -I $(LIBDIR) #-DQEMU_DEBUG
+
 ifneq ($(TKEY_SIGNER_APP_NO_TOUCH),)
 CFLAGS := $(CFLAGS) -DTKEY_SIGNER_APP_NO_TOUCH
 endif
@@ -22,9 +22,7 @@ endif
 AS = clang
 ASFLAGS = -target riscv32-unknown-none-elf -march=rv32iczmmul -mabi=ilp32 -mcmodel=medany -mno-relax
 
-LDFLAGS=-T $(LIBDIR)/app.lds -L $(LIBDIR)/libcommon/ -lcommon -L $(LIBDIR)/libcrt0/ -lcrt0
-
-RM=/bin/rm
+LDFLAGS=-T $(LIBDIR)/app.lds -L $(LIBDIR) -lcommon -lcrt0
 
 
 .PHONY: all
@@ -45,11 +43,11 @@ check-signer-hash: signer/app.bin
 SIGNEROBJS=signer/main.o signer/app_proto.o
 signer/app.elf: $(SIGNEROBJS)
 	$(CC) $(CFLAGS) $(SIGNEROBJS) $(LDFLAGS) -L $(LIBDIR)/monocypher -lmonocypher -I $(LIBDIR) -o $@
-$(SIGNEROBJS): $(INCLUDE)/tk1_mem.h signer/app_proto.h
+$(SIGNEROBJS): $(INCLUDE)/tkey/tk1_mem.h signer/app_proto.h
 
 .PHONY: clean
 clean:
-	$(RM) -f signer/app.bin signer/app.elf $(SIGNEROBJS)
+	rm -f signer/app.bin signer/app.elf $(SIGNEROBJS)
 
 # Uses ../.clang-format
 FMTFILES=signer/*.[ch]

--- a/signer/app_proto.c
+++ b/signer/app_proto.c
@@ -1,7 +1,7 @@
 // Copyright (C) 2022, 2023 - Tillitis AB
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include <qemu_debug.h>
+#include <tkey/qemu_debug.h>
 
 #include "app_proto.h"
 

--- a/signer/app_proto.h
+++ b/signer/app_proto.h
@@ -4,8 +4,8 @@
 #ifndef APP_PROTO_H
 #define APP_PROTO_H
 
-#include <lib.h>
-#include <proto.h>
+#include <tkey/lib.h>
+#include <tkey/proto.h>
 
 // clang-format off
 enum appcmd {

--- a/signer/main.c
+++ b/signer/main.c
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include <monocypher/monocypher-ed25519.h>
-#include <qemu_debug.h>
-#include <tk1_mem.h>
+#include <tkey/qemu_debug.h>
+#include <tkey/tk1_mem.h>
 
 #include "app_proto.h"
 
@@ -50,7 +50,7 @@ touched:
 
 int main(void)
 {
-#ifndef NODEBUG
+#ifdef QEMU_DEBUG
 	uint32_t stack;
 #endif
 	uint8_t pubkey[32];
@@ -73,7 +73,7 @@ int main(void)
 	*cpu_mon_last = TK1_RAM_BASE + TK1_RAM_SIZE;
 	*cpu_mon_ctrl = 1;
 
-#ifndef NODEBUG
+#ifdef QEMU_DEBUG
 	qemu_puts("Hello! &stack is on: ");
 	qemu_putinthex((uint32_t)&stack);
 	qemu_lf();


### PR DESCRIPTION
Include the changes from tkey-libs v0.0.2.

Does not change the sha512 of the binary.

Also removed `RM=/bin/rm` in favor of just `rm`. 