### PR TITLE
make: Add target for compile_commands.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,13 @@ LDFLAGS=-T $(LIBDIR)/app.lds -L $(LIBDIR) -lcommon -lcrt0
 .PHONY: all
 all: signer/app.bin check-signer-hash
 
+# Create compile_commands.json for clangd and LSP
+.PHONY: clangd
+clangd: compile_commands.json
+compile_commands.json:
+	$(MAKE) clean
+	bear -- make signer/app.bin
+
 # Turn elf into bin for device
 %.bin: %.elf
 	$(OBJCOPY) --input-target=elf32-littleriscv --output-target=binary $^ $@


### PR DESCRIPTION
## Description

As a convenience to developers, add a make target to create `compile_commands.json` to feed `clangd` for LSP support.

## Type of change

- [x] Feature (non breaking change which adds functionality)

No code changes. Doesn't change CDI

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have updated the documentation where relevant (readme,
      dev.tillitis.se etc.)

  Do we mention this in README?


