### PR TITLE
Document building with pre-built tkey-libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ LIBDIR ?= $(P)/../tkey-libs
 
 CC = clang
 
-INCLUDE=$(LIBDIR)/include
+INCLUDE = $(LIBDIR)/include
 
 # If you want libcommon's qemu_puts() et cetera to output something on our QEMU
 # debug port, use -DQEMU_DEBUG below

--- a/README.md
+++ b/README.md
@@ -133,7 +133,23 @@ These scripts automatilly clone the [tkey-libs device
 libraries](https://github.com/tillitis/tkey-libs) in a directory next
 to this one.
 
-### Installing Podman
+If you want to use a pre-built libraries, download the libraries tar
+ball from
+
+https://github.com/tillitis/tkey-libs/releases
+
+unpack it, and specify where you unpacked it in `LIBDIR` when
+building:
+
+```
+make LIBDIR=~/Downloads/tkey-libs-v0.1.1
+```
+
+Note that your `lld` might complain if they were built with a
+different version. If so, either use the same version the release used
+or use podman.
+
+### Building with Podman
 
 On Ubuntu 22.10, running
 
@@ -142,6 +158,22 @@ apt install podman rootlesskit slirp4netns
 ```
 
 should be enough to get you a working Podman setup.
+
+You can then either:
+
+- Use `build-podman.sh` as described above, which clones and builds
+  the tkey-libs libraries as well.
+
+- Download [pre-built versions of the tkey-libs
+  libraries](https://github.com/tillitis/tkey-libs/releases) and
+  define `LIBDIR` to where you unpacked the tkey-libs, something
+  like:
+
+  ```
+  make LIBDIR=$HOME/Downloads/tkey-libs-v0.1.1 podman
+  ```
+
+  Note that `~` expansion doesn't work.
 
 ### Building with host tools
 


### PR DESCRIPTION
## Description

We distribute pre-built tkey-libs as Github releases. This patch documents how to use it by defining `LIBDIR` to where you unpacked the tar ball.

There are a few gotchas, mostly where LLVM's linker will complain if they are too far apart in versions (probably major versions).

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Feature (non breaking change which adds functionality)
- [x] Documentation (a change to documentation)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)

