### PR TITLE
Allow overriding clang-tidy as in 'make CLANG_TIDY=clang-tidy-17'.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,11 @@ check-signer-hash: signer/app.bin show-signer-hash
 	@cat signer/app.bin.sha512
 	$(shasum) -c signer/app.bin.sha512
 
+CLANG_TIDY = clang-tidy
+
 .PHONY: check
 check:
-	clang-tidy -header-filter=.* -checks=cert-* signer/*.[ch] -- $(CFLAGS)
+	$(CLANG_TIDY) -header-filter=.* -checks=cert-* signer/*.[ch] -- $(CFLAGS)
 
 # Simple ed25519 signer app
 SIGNEROBJS=signer/main.o signer/app_proto.o


### PR DESCRIPTION
Hi!  The makefile supports overriding `CC` and `AS` which may be needed if you are using versioned compilers like `make CC=clang-18` however the call to `clang-tidy` is hard coded and doesn't allow versioned overrides.  This patch fixes this.

Thanks,
Simon