### PR TITLE
Allow overriding clang-tidy as in 'make CLANG_TIDY=clang-tidy-17'.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,11 @@ check-signer-hash: signer/app.bin show-signer-hash
 	@cat signer/app.bin.sha512
 	$(shasum) -c signer/app.bin.sha512
 
+CLANG_TIDY = clang-tidy
+
 .PHONY: check
 check:
-	clang-tidy -header-filter=.* -checks=cert-* signer/*.[ch] -- $(CFLAGS)
+	$(CLANG_TIDY) -header-filter=.* -checks=cert-* signer/*.[ch] -- $(CFLAGS)
 
 # Simple ed25519 signer app
 SIGNEROBJS=signer/main.o signer/app_proto.o


### PR DESCRIPTION
## Description

PR #21 rebased on main

Fixes # (issues)

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Feature (non breaking change which adds functionality)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
